### PR TITLE
Closes #15 – Removes Zero Division Error

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -62,7 +62,10 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
+        if len(ratings) == 0:
+            avg = 0
+        else:
+            avg = total_rating / len(ratings)
         return avg
 
     class Meta:

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -68,12 +68,6 @@ class Product(SafeDeleteModel):
             avg = 0
         return avg
 
-        # if len(ratings) == 0:
-        #     avg = 0
-        # else:
-        #     avg = total_rating / len(ratings)
-        # return avg
-
     class Meta:
         verbose_name = ("product")
         verbose_name_plural = ("products")

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -62,11 +62,17 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        if len(ratings) == 0:
-            avg = 0
-        else:
+        try:
             avg = total_rating / len(ratings)
+        except ZeroDivisionError:
+            avg = 0
         return avg
+
+        # if len(ratings) == 0:
+        #     avg = 0
+        # else:
+        #     avg = total_rating / len(ratings)
+        # return avg
 
     class Meta:
         verbose_name = ("product")


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- In `bangazonapi/models/product.py `, added logic for checking the length of a product's rating list

## Requests / Responses

**Request**

GET `/products/50` Return a single product

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 50,
    "name": "Escalade EXT",
    "price": 926.92,
    "number_sold": 2,
    "description": "2008 Cadillac",
    "quantity": 2,
    "created_date": "2019-02-01",
    "location": "Lokavec",
    "image_path": null,
    "average_rating": 3.25
}
```

## Testing

Testing can be run through Postman using the `collections/Bangazon Python API/Products/Get all products` path OR  `collections/Bangazon Python API/Products/Get product 50` 

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Navigate to Postman. Run a `GET` to http://localhost:8000/products
- [ ] Confirm that all products are being returned, regardless of a 0 `average_rating`


## Related Issues

- Fixes #15 