### PR TITLE
Closes #18 – payment type returned by author

### DIFF
--- a/bangazonapi/models/payment.py
+++ b/bangazonapi/models/payment.py
@@ -3,11 +3,13 @@ from .customer import Customer
 from safedelete.models import SafeDeleteModel
 from safedelete.models import SOFT_DELETE
 
-class Payment(SafeDeleteModel):
 
+class Payment(SafeDeleteModel):
+    """Also known as the payment type model"""
     _safedelete_policy = SOFT_DELETE
     merchant_name = models.CharField(max_length=25,)
     account_number = models.CharField(max_length=25)
-    customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING, related_name="payment_types")
+    customer = models.ForeignKey(
+        Customer, on_delete=models.DO_NOTHING, related_name="payment_types")
     expiration_date = models.DateField(default="0000-00-00",)
     create_date = models.DateField(default="0000-00-00",)

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -20,7 +20,8 @@ class PaymentSerializer(serializers.HyperlinkedModelSerializer):
             lookup_field='id'
         )
         fields = ('id', 'url', 'merchant_name', 'account_number',
-                  'expiration_date', 'create_date')
+                  'expiration_date', 'create_date', 'customer_id')
+        depth = 1
 
 
 class Payments(ViewSet):
@@ -81,7 +82,8 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer = Customer.objects.get(user=request.auth.user)
+        customer_id = customer.id
 
         if customer_id is not None:
             payment_types = payment_types.filter(customer__id=customer_id)


### PR DESCRIPTION
## Changes

- In `bangazonapi/views/paymenttype.py`, changed logic for checking the token instead of param, then filtering based off that criteria 


## Requests / Responses

**Request**

GET `/paymenttypes`;

In Headers, pass: KEY: `Authorization`, VALUE: `Token 9ba45f09651c5b0c404f37a2d2572c026c146688 `


**Response**

HTTP/1.1 201 OK

```json
[
    {
        "id": 2,
        "url": "http://localhost:8000/paymenttypes/2",
        "merchant_name": "Mastercard",
        "account_number": "39j3984fj9sofi9",
        "expiration_date": "2020-02-01",
        "create_date": "2019-12-12",
        "customer_id": 6
    }
]
```

## Testing

- [ ] Clone this repository
- [ ] `git checkout 18-payment-types`
- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Navigate to Postman, change URL to `http://localhost:8000/paymenttypes`
- [ ] In Headers, pass: KEY: `Authorization`, VALUE: `Token 9ba45f09651c5b0c404f37a2d2572c026c146688 `
- [ ] Send `GET` request. Confirm that payment type with a `customer_id` of 6 is returned.
- [ ] Try with a different token. In Headers, pass: KEY: `Authorization`, VALUE: `Token 9ba45f09651c5b0c404f37a2d2572c026c14669c `
- [ ] Send `GET` request. Confirm that payment type with a `customer_id` of 7 is returned.


## Related Issues

- Fixes #18 