### PR TITLE
Closes #21 – Minimum Products Sold 

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -272,7 +272,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
## Changes

- In `bangazonapi/views/product.py `, flipped a less than to a greater than, thus changing the conditional our filter is checking against


## Requests / Responses

**Request**

GET `/http://localhost:8000/products?number_sold=1` Retrieves products with AT LEAST one unit sold

**Response**

HTTP/1.1 201 OK

```json
[
    {
        "id": 45,
        "name": "Corvette",
        "price": 795.8,
        "number_sold": 1,
        "description": "1987 Chevrolet",
        "quantity": 2,
        "created_date": "2019-10-07",
        "location": "Ueno",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25
    }
]
```

## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Navigate to postman, go to `collections/Bangazon Python API/Products that have sold 2 or more`
- [ ] Amend URL to `/http://localhost:8000/products?number_sold=1`, run GET
- [ ] Verify only two products are returned, both with quantities of at least 1 unit sold


## Related Issues

- Fixes #21 