### PR TITLE
Closes #11 – Test for completing order with payment type passes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,3 @@
 [FORMAT]
 good-names=i,j,ex,pk
+disable=no-member

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
 from rest_framework.decorators import action
-from bangazonapi.models import Order, Payment, Customer, Product, OrderProduct, payment
+from bangazonapi.models import Order, Payment, Customer, OrderProduct
 from .product import ProductSerializer
 
 

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer order"""
+from bangazonapi.views.paymenttype import PaymentSerializer
 import datetime
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
@@ -6,7 +7,7 @@ from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
 from rest_framework.decorators import action
-from bangazonapi.models import Order, Payment, Customer, Product, OrderProduct
+from bangazonapi.models import Order, Payment, Customer, Product, OrderProduct, payment
 from .product import ProductSerializer
 
 
@@ -29,6 +30,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
     lineitems = OrderLineItemSerializer(many=True)
+    payment_type = PaymentSerializer()
 
     class Meta:
         model = Order
@@ -38,6 +40,8 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
         )
         fields = ('id', 'url', 'created_date',
                   'payment_type', 'customer', 'lineitems')
+
+        depth = 1
 
 
 class Orders(ViewSet):
@@ -73,7 +77,7 @@ class Orders(ViewSet):
             customer = Customer.objects.get(user=request.auth.user)
             order = Order.objects.get(pk=pk, customer=customer)
             serializer = OrderSerializer(order, context={'request': request})
-            return Response(serializer.data)
+            return Response(serializer.data, status=status.HTTP_200_OK)
 
         except Order.DoesNotExist as ex:
             return Response(

--- a/tests/order.py
+++ b/tests/order.py
@@ -67,7 +67,6 @@ class OrderTests(APITestCase):
 
         # Get cart and verify product was added
         url = "/cart"
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.get(url, None, format='json')
         json_response = json.loads(response.content)
 
@@ -86,14 +85,12 @@ class OrderTests(APITestCase):
         # Remove product from cart
         url = "/cart/1"
         data = {"product_id": 1}
-        # self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.delete(url, data, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # Get cart and verify product was removed
         url = "/cart"
-        # self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.get(url, None, format='json')
         json_response = json.loads(response.content)
 
@@ -105,32 +102,23 @@ class OrderTests(APITestCase):
         """
         Test to make sure orders are being closed as a payment type is added.
         """
-        # self.test_add_product_to_order()
 
         # Create a payment type
-        # url = "/paymenttypes"
-        # data = {"merchant_name": "Amex", "account_number": "2222222",
-        #         "expiration_date": "2025-12-12", "create_date": "2019-01-01"}
-        # self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        # response = self.client.post(url, data, format='json')
-        # self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        # Already accomplished in set up
 
         # Add that created payment type to the cart with PUT
         data = {"payment_type": 1}
 
         # self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.put(f"/order/1", data, format="json")
+        response = self.client.put("/orders/1", data, format="json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        # SO, to fix this test, you COULD change this to a 404...but that doesn't feel right
 
         # Get cart and veryify payment type has been added
-        url = "/cart"
-        # self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.get(url, None, format='json')
-        print("--------------- LABEL:", response.json())
+        response = self.client.get("/orders/1", None, format='json')
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(json_response["size"], 1)
-        self.assertEqual(len(json_response["lineitems"]), 1)
+        self.assertEqual(json_response["payment_type"]["id"], 1)
 
     # TODO: New line item is not added to closed order

--- a/tests/order.py
+++ b/tests/order.py
@@ -1,7 +1,7 @@
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
-from bangazonapi.models import Customer, Order, OrderProduct, Product, Payment, ProductCategory
+from bangazonapi.models import Order, OrderProduct, Payment
 
 
 class OrderTests(APITestCase):


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- In `bangazonapi/views/order.py `, carried over PaymentSerializer, which enables id of payment type to be accessible in an order dictionary
- In `tests/order.py `, created test to check if the addition of a payment type would close an order
- In `tests/order.py `, improved set up and removed redundancies of things like auth token checks

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] In terminal, run `python manage.py test tests.order -v 1`
- [ ] Confirm three tests are passing


## Related Issues

- Closes #11 