### PR TITLE
Closes #14 – Can get products by location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -254,6 +254,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        location = self.request.query_params.get('location', None)
 
         if order is not None:
             order_filter = order
@@ -269,6 +270,9 @@ class Products(ViewSet):
 
         if quantity is not None:
             products = products.order_by("-created_date")[:int(quantity)]
+
+        if location is not None:
+            products = products.filter(location__contains=location)
 
         if number_sold is not None:
             def sold_filter(product):


### PR DESCRIPTION
## Changes

- In `bangazonapi/views/product.py `, added logic for checking location query string parameter.

## Requests / Responses

**Request**

GET `http://localhost:8000/products?location=ke`, in Headers pass: KEY: `Authorization `, VALUE: `Token 9ba45f09651c5b0c404f37a2d2572c026c14669c`

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 18,
        "name": "Impala",
        "price": 954.15,
        "number_sold": 0,
        "description": "2007 Chevrolet",
        "quantity": 1,
        "created_date": "2019-02-10",
        "location": "Ke’erlun",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 68,
        "name": "CX-9",
        "price": 1750.74,
        "number_sold": 0,
        "description": "2011 Mazda",
        "quantity": 4,
        "created_date": "2019-05-21",
        "location": "Qiankeng",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 94,
        "name": "Eclipse",
        "price": 1139.37,
        "number_sold": 0,
        "description": "2002 Mitsubishi",
        "quantity": 2,
        "created_date": "2019-08-29",
        "location": "Pryazovs’ke",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing


- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Run GET request above, use any known location you'd like
- [ ] JSON response should only return products with a location string containing the search parameter


## Related Issues

- Fixes #14 